### PR TITLE
Add URL scheme validation

### DIFF
--- a/scraper_images.py
+++ b/scraper_images.py
@@ -90,6 +90,9 @@ def _find_product_name(driver: webdriver.Chrome) -> str:
 
 
 def download_images(url: str, css_selector: str = DEFAULT_CSS_SELECTOR) -> None:
+    if not url.lower().startswith(("http://", "https://")):
+        raise ValueError("URL must start with http:// or https://")
+
     driver = _setup_driver()
 
     product_name = ""
@@ -139,5 +142,7 @@ if __name__ == "__main__":
             f"\U0001F3AF Classe CSS des images [défaut: {DEFAULT_CSS_SELECTOR}] : "
         ).strip() or DEFAULT_CSS_SELECTOR
         download_images(product_url, selector)
+    except ValueError as exc:
+        print(f"Erreur : {exc}")
     except KeyboardInterrupt:
         print("\nInterruption par l'utilisateur.")


### PR DESCRIPTION
## Summary
- validate URL scheme before launching the browser
- display a user-friendly error when an unsupported scheme is provided

## Testing
- `python -m py_compile scraper_images.py`

------
https://chatgpt.com/codex/tasks/task_e_686690aaf6448330a1aa536b4ac090b4