### PR TITLE
Add audit log info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ bash
 Copier
 Modifier
 pip install selenium webdriver-manager tqdm requests
+
+🗒️ Suivi des audits
+Les rapports d'audit sont enregistrés dans `compte_rendu.txt`. Mettez ce fichier à jour à chaque nouvel audit. Pour consulter les derniers résultats, ouvrez `compte_rendu.txt` ou exécutez `cat compte_rendu.txt` dans votre terminal.


### PR DESCRIPTION
## Summary
- document audit log usage in README

## Testing
- `python3 -m py_compile scraper_images.py`


------
https://chatgpt.com/codex/tasks/task_e_6866953bf6288330a5bfdf95c929124b