### PR TITLE
Allow selector from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Un outil Python robuste et évolutif pour scraper automatiquement les images de 
 ✅ Téléchargement des images depuis une page produit
 ✅ Détection des images base64 intégrées (et sauvegarde locale)
 ✅ Nettoyage automatique des noms de produits / fichiers
-✅ Sélecteur CSS personnalisable via la console
+✅ Sélecteur CSS personnalisable via l'option `--selector`
 ✅ Création automatique de sous-dossiers par produit
 ✅ Progression affichée avec tqdm
 ✅ Résumé final clair dans la console
 ✅ Extraction des noms et liens de produits d'une collection (scrap_lien_collection.py)
-Exemple : `python scrap_lien_collection.py https://exemple.com/collection`
+Exemple : `python scrap_lien_collection.py https://exemple.com/collection --selector "div.product a"`
 
 
 🛠️ Dépendances

--- a/scrap_lien_collection.py
+++ b/scrap_lien_collection.py
@@ -145,6 +145,12 @@ def main() -> None:
         help="Niveau de logging (defaut: %(default)s)",
     )
     parser.add_argument(
+        "-s",
+        "--selector",
+        default=DEFAULT_SELECTOR,
+        help="Selecteur CSS des liens produits (defaut: %(default)s)",
+    )
+    parser.add_argument(
         "--next-selector",
         default=DEFAULT_NEXT_SELECTOR,
         help="Selecteur CSS du bouton 'page suivante' (defaut: %(default)s)",
@@ -159,12 +165,8 @@ def main() -> None:
         format="%(asctime)s %(levelname)s %(message)s",
     )
 
-    print(f"\U0001F7E1 Selecteur CSS par defaut : {DEFAULT_SELECTOR}")
-    user_input = input(
-        "Souhaitez-vous utiliser un autre selecteur CSS ? (laisser vide pour garder le defaut) : "
-    ).strip()
-    css_selector = user_input or DEFAULT_SELECTOR
-
+    css_selector = args.selector
+    print(f"\U0001F7E1 Selecteur CSS utilise : {css_selector}")
     print(
         f"\U0001F7E1 Selecteur CSS pour le bouton 'page suivante' : {args.next_selector}"
     )


### PR DESCRIPTION
## Summary
- add `--selector` option to `scrap_lien_collection.py`
- use this option instead of prompting the user
- update docs with new option

## Testing
- `python -m py_compile scrap_lien_collection.py scraper_images.py`

------
https://chatgpt.com/codex/tasks/task_e_6866b2f02fbc8330a6965ca0f3b5ee5e