### PR TITLE
Ajout module de scraping de descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Un outil Python robuste et évolutif pour scraper automatiquement les images de 
 ✅ Progression affichée avec tqdm
 ✅ Résumé final clair dans la console
 ✅ Extraction des noms et liens de produits d'une collection (scrap_lien_collection.py)
+✅ Récupération de la description HTML d'un produit (scrap_description_produit.py)
 Exemple : `python scrap_lien_collection.py https://exemple.com/collection --selector "div.product a"`
 
 Pour tester ou générer rapidement un sélecteur CSS depuis un extrait HTML,

--- a/compte_rendu.txt
+++ b/compte_rendu.txt
@@ -12,3 +12,13 @@ Audit de scraper_images.py
 6. Journalisation configurable via le module `logging`.
 
 Ces améliorations renforcent la fiabilité et la sécurité lors du scraping d'images.
+
+Audit de scrap_description_produit.py
+====================================
+
+Le module extrait la description HTML d'une page produit.
+
+1. WebDriver headless configuré avec masquage de l'automatisation.
+2. Utilisation de `WebDriverWait` pour attendre la présence de l'élément ciblé.
+3. Validation de l'URL en `http` ou `https`.
+4. Sauvegarde UTF-8 de la description dans un fichier fourni.

--- a/interface_py.py
+++ b/interface_py.py
@@ -22,6 +22,7 @@ from PySide6.QtCore import QThread, Signal
 
 import scrap_lien_collection
 import scraper_images
+import scrap_description_produit
 
 
 class QtLogHandler(logging.Handler):
@@ -96,6 +97,36 @@ class ScraperImagesWorker(QThread):
                 css_selector=self.selector,
                 dest_dir=self.dest,
                 progress_callback=lambda i, t: self.progress.emit(int(i / t * 100)),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("%s", exc)
+        finally:
+            logger.removeHandler(handler)
+            self.finished.emit()
+
+
+class ScrapDescriptionWorker(QThread):
+    """Background worker to extract and save product descriptions."""
+
+    log = Signal(str)
+    finished = Signal()
+
+    def __init__(self, url: str, selector: str, output: Path):
+        super().__init__()
+        self.url = url
+        self.selector = selector
+        self.output = output
+
+    def run(self) -> None:
+        logger = logging.getLogger()
+        logger.setLevel(logging.INFO)
+        handler = QtLogHandler(self.log)
+        formatter = logging.Formatter("%(levelname)s: %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        try:
+            scrap_description_produit.scrape_description(
+                self.url, self.selector, self.output
             )
         except Exception as exc:  # noqa: BLE001
             logger.error("%s", exc)
@@ -218,6 +249,56 @@ class PageScraperImages(QWidget):
         self.button_start.setEnabled(True)
 
 
+class PageScrapDescription(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+
+        self.input_url = QLineEdit()
+        self.input_url.setPlaceholderText("URL du produit")
+        layout.addWidget(QLabel("URL du produit"))
+        layout.addWidget(self.input_url)
+
+        self.input_selector = QLineEdit(scrap_description_produit.DEFAULT_SELECTOR)
+        layout.addWidget(QLabel("Sélecteur CSS"))
+        layout.addWidget(self.input_selector)
+
+        self.input_output = QLineEdit("description.html")
+        layout.addWidget(QLabel("Fichier de sortie"))
+        layout.addWidget(self.input_output)
+
+        self.button_start = QPushButton("Extraire")
+        layout.addWidget(self.button_start)
+
+        self.log_view = QPlainTextEdit()
+        self.log_view.setReadOnly(True)
+        layout.addWidget(self.log_view)
+        layout.addStretch()
+
+        self.worker: ScrapDescriptionWorker | None = None
+        self.button_start.clicked.connect(self.start_worker)
+
+    def start_worker(self) -> None:
+        url = self.input_url.text().strip()
+        selector = self.input_selector.text().strip() or scrap_description_produit.DEFAULT_SELECTOR
+        output = Path(self.input_output.text().strip() or "description.html")
+
+        if not url:
+            self.log_view.appendPlainText("Veuillez renseigner l'URL.")
+            return
+
+        self.button_start.setEnabled(False)
+        self.log_view.clear()
+
+        self.worker = ScrapDescriptionWorker(url, selector, output)
+        self.worker.log.connect(self.log_view.appendPlainText)
+        self.worker.finished.connect(self.on_finished)
+        self.worker.start()
+
+    def on_finished(self) -> None:
+        self.button_start.setEnabled(True)
+
+
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
@@ -226,12 +307,15 @@ class MainWindow(QMainWindow):
         self.menu = QListWidget()
         self.menu.addItem("Scrap Liens Collection")
         self.menu.addItem("Scraper Images")
+        self.menu.addItem("Scrap Description")
 
         self.stack = QStackedWidget()
         self.page_scrap = PageScrapLienCollection()
         self.page_images = PageScraperImages()
+        self.page_desc = PageScrapDescription()
         self.stack.addWidget(self.page_scrap)
         self.stack.addWidget(self.page_images)
+        self.stack.addWidget(self.page_desc)
 
         self.menu.currentRowChanged.connect(self.stack.setCurrentIndex)
 

--- a/scrap_description_produit.py
+++ b/scrap_description_produit.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Extract the HTML description of a product page using Selenium."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from webdriver_manager.chrome import ChromeDriverManager
+
+DEFAULT_SELECTOR = ".rte"
+
+
+def _setup_driver() -> webdriver.Chrome:
+    """Return a configured headless Chrome WebDriver."""
+    options = Options()
+    options.add_argument("--headless")
+    options.add_experimental_option("excludeSwitches", ["enable-automation"])
+    options.add_experimental_option("useAutomationExtension", False)
+    options.add_argument("--disable-blink-features=AutomationControlled")
+
+    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+    driver.execute_cdp_cmd(
+        "Page.addScriptToEvaluateOnNewDocument",
+        {"source": "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"},
+    )
+    return driver
+
+
+def extract_html_description(url: str, css_selector: str = DEFAULT_SELECTOR) -> str:
+    """Return the inner HTML of the first element matching *css_selector* on *url*."""
+    if not url.lower().startswith(("http://", "https://")):
+        raise ValueError("URL must start with http:// or https://")
+
+    driver = _setup_driver()
+    try:
+        driver.get(url)
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, css_selector))
+        )
+        element = driver.find_element(By.CSS_SELECTOR, css_selector)
+        html = element.get_attribute("innerHTML")
+        logging.info("\u2714\ufe0f HTML extrait avec succès")
+        return html.strip()
+    finally:
+        driver.quit()
+
+
+def save_html_to_file(html: str, filename: Path = Path("description.html")) -> None:
+    """Save *html* into *filename* encoded as UTF-8."""
+    filename.write_text(html, encoding="utf-8")
+    logging.info("\U0001F4BE Description enregistrée dans %s", filename.resolve())
+
+
+def scrape_description(url: str, selector: str, output: Path) -> None:
+    """High level helper combining extraction and saving."""
+    html = extract_html_description(url, selector)
+    save_html_to_file(html, output)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extraire la description HTML d'un produit et la sauvegarder dans un fichier.",
+    )
+    parser.add_argument(
+        "url",
+        nargs="?",
+        help="URL du produit (si absent, demande à l'exécution)",
+    )
+    parser.add_argument(
+        "-s",
+        "--selector",
+        default=DEFAULT_SELECTOR,
+        help="Sélecteur CSS de la description (defaut: %(default)s)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="description.html",
+        help="Fichier de sortie (defaut: %(default)s)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Niveau de logging (defaut: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    if not args.url:
+        args.url = input("\U0001F517 Entrez l'URL du produit : ").strip()
+
+    logging.basicConfig(level=getattr(logging, args.log_level), format="%(levelname)s: %(message)s")
+
+    try:
+        scrape_description(args.url, args.selector, Path(args.output))
+    except Exception as exc:
+        logging.error("%s", exc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ajouter `scrap_description_produit.py` pour récupérer la description HTML d'un produit
- intégrer ce module dans `interface_py.py` via un nouvel onglet "Scrap Description"
- mettre à jour la documentation et le fichier d'audit

## Testing
- `python -m py_compile scrap_description_produit.py interface_py.py scrap_lien_collection.py scraper_images.py find_css_selector.py`


------
https://chatgpt.com/codex/tasks/task_e_6867febf3ca883308291dc720b0ba548