### PR TITLE
Fix menu width

### DIFF
--- a/interface_py.py
+++ b/interface_py.py
@@ -305,6 +305,7 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("Interface Py")
 
         self.menu = QListWidget()
+        self.menu.setMaximumWidth(150)
         self.menu.addItem("Scrap Liens Collection")
         self.menu.addItem("Scraper Images")
         self.menu.addItem("Scrap Description")


### PR DESCRIPTION
## Summary
- limit `MainWindow` menu width so the list widget takes less space

## Testing
- `python -m py_compile interface_py.py`


------
https://chatgpt.com/codex/tasks/task_e_6868f5c5eebc83308b2af0cc3e0c1ddf