### PR TITLE
Enhance scrap module UI

### DIFF
--- a/interface_py.py
+++ b/interface_py.py
@@ -173,12 +173,48 @@ class PageScrapLienCollection(QWidget):
         layout.addWidget(self.combo_log)
 
         self.button_start = QPushButton("Lancer le scraping")
+        self.button_start.setStyleSheet(
+            """
+            QPushButton {
+                background-color: #007BFF;
+                color: white;
+                border-radius: 8px;
+                padding: 8px 16px;
+                font-weight: bold;
+                font-size: 14px;
+                border: none;
+            }
+            QPushButton:hover {
+                background-color: #0056b3;
+            }
+            QPushButton:pressed {
+                background-color: #003d80;
+            }
+            QPushButton:disabled {
+                background-color: #cccccc;
+                color: #666666;
+            }
+            """
+        )
         layout.addWidget(self.button_start)
         self.button_start.clicked.connect(self.start_worker)
 
 
         self.log_view = QPlainTextEdit()
         self.log_view.setReadOnly(True)
+        self.log_view.setStyleSheet(
+            """
+            QPlainTextEdit {
+                background-color: #fdfdfd;
+                color: #222222;
+                font-family: Consolas, \"Courier New\", monospace;
+                font-size: 13px;
+                border: 1px solid #cccccc;
+                border-radius: 6px;
+                padding: 6px;
+            }
+            """
+        )
         layout.addWidget(self.log_view)
 
         layout.addStretch()


### PR DESCRIPTION
## Summary
- style the start button and log output for the scrap liens collection page

## Testing
- `python -m py_compile interface_py.py scrap_lien_collection.py scrap_description_produit.py scraper_images.py find_css_selector.py`
- `python interface_py.py` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_686907eda3dc8330a0dc9b62392bd817