### PR TITLE
Add checkbox to toggle logs console

### DIFF
--- a/interface_py.py
+++ b/interface_py.py
@@ -22,7 +22,7 @@ from PySide6.QtWidgets import (
     QSpinBox,
     QFontComboBox,
 )
-from PySide6.QtCore import QThread, Signal
+from PySide6.QtCore import QThread, Signal, Qt
 from PySide6.QtGui import QFont
 
 import scrap_lien_collection
@@ -259,7 +259,14 @@ class PageScraperImages(QWidget):
         layout.addWidget(self.input_options)
 
         self.checkbox_preview = QCheckBox("Afficher le dossier après téléchargement")
-        layout.addWidget(self.checkbox_preview)
+        self.checkbox_show_console = QCheckBox("Afficher la console")
+        self.checkbox_show_console.setChecked(True)
+        self.checkbox_show_console.stateChanged.connect(self.toggle_console_visibility)
+
+        checkbox_layout = QHBoxLayout()
+        checkbox_layout.addWidget(self.checkbox_preview)
+        checkbox_layout.addWidget(self.checkbox_show_console)
+        layout.addLayout(checkbox_layout)
 
         self.button_start = QPushButton("Scraper")
         layout.addWidget(self.button_start)
@@ -340,6 +347,9 @@ class PageScraperImages(QWidget):
         self.manager.save_setting("images_file", self.input_urls_file.text())
         self.manager.save_setting("images_dest", self.input_dest.text())
         self.manager.save_setting("images_selector", self.input_options.text())
+
+    def toggle_console_visibility(self, state: int) -> None:
+        self.log_view.setVisible(state == Qt.Checked)
 
 
 class PageScrapDescription(QWidget):


### PR DESCRIPTION
## Summary
- add Qt enum import
- show/hide console in Scraper Images page via checkbox

## Testing
- `python -m py_compile interface_py.py settings_manager.py scraper_images.py scrap_lien_collection.py scrap_description_produit.py find_css_selector.py`

------
https://chatgpt.com/codex/tasks/task_e_686912635310833094e52b1721b6d474