### PR TITLE
Set progress bar text color to black

### DIFF
--- a/settings_manager.py
+++ b/settings_manager.py
@@ -131,6 +131,7 @@ def apply_settings(app, settings: dict) -> None:
         padding: 6px;
     }}
     QProgressBar {{
+        color: #000000;
         border: 2px solid #555;
         border-radius: 5px;
         text-align: center;


### PR DESCRIPTION
## Summary
- update stylesheet in `apply_settings` to ensure progress bar text is black

## Testing
- `python -m py_compile interface_py.py settings_manager.py scraper_images.py scrap_description_produit.py scrap_lien_collection.py find_css_selector.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869143db1f08330a2b808c8fde7e4a3