### PR TITLE
Fix incorrect QRect import in interface_py

### DIFF
--- a/interface_py.py
+++ b/interface_py.py
@@ -23,8 +23,15 @@ from PySide6.QtWidgets import (
     QFontComboBox,
     QTextEdit,
 )
-from PySide6.QtCore import QThread, Signal, Qt, QPropertyAnimation, Property
-from PySide6.QtGui import QFont, QPainter, QColor, QRect, QPixmap
+from PySide6.QtCore import (
+    QThread,
+    Signal,
+    Qt,
+    QPropertyAnimation,
+    Property,
+    QRect,
+)
+from PySide6.QtGui import QFont, QPainter, QColor, QPixmap
 
 import scrap_lien_collection
 import scraper_images


### PR DESCRIPTION
## Summary
- import QRect from `PySide6.QtCore`
- tidy import block

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686919bdcc90833089fe86dd1d90d8a9