### PR TITLE
Add profiles tab with SiteProfileManager

### DIFF
--- a/interface_py.py
+++ b/interface_py.py
@@ -37,6 +37,7 @@ import scrap_lien_collection
 import scraper_images
 import scrap_description_produit
 from settings_manager import SettingsManager, apply_settings
+from site_profile_manager import SiteProfileManager
 
 
 class QtLogHandler(logging.Handler):
@@ -211,6 +212,129 @@ class ScrapDescriptionWorker(QThread):
         finally:
             logger.removeHandler(handler)
             self.finished.emit()
+
+
+class PageProfiles(QWidget):
+    """Manage site profiles (selectors)."""
+
+    def __init__(self, profile_manager: SiteProfileManager, main_window) -> None:
+        super().__init__()
+        self.profile_manager = profile_manager
+        self.main_window = main_window
+
+        layout = QVBoxLayout(self)
+
+        self.combo_profiles = QComboBox()
+        layout.addWidget(QLabel("Profils existants"))
+        layout.addWidget(self.combo_profiles)
+
+        self.input_name = QLineEdit()
+        layout.addWidget(QLabel("Nom du profil"))
+        layout.addWidget(self.input_name)
+
+        self.input_images = QLineEdit()
+        layout.addWidget(QLabel("Sélecteur Images"))
+        layout.addWidget(self.input_images)
+
+        self.input_desc = QLineEdit()
+        layout.addWidget(QLabel("Sélecteur Description"))
+        layout.addWidget(self.input_desc)
+
+        self.input_collection = QLineEdit()
+        layout.addWidget(QLabel("Sélecteur Collection"))
+        layout.addWidget(self.input_collection)
+
+        self.checkbox_auto = QCheckBox("Appliquer automatiquement après chargement")
+        layout.addWidget(self.checkbox_auto)
+
+        btn_layout = QHBoxLayout()
+        self.button_new = QPushButton("Nouveau")
+        self.button_save = QPushButton("Sauvegarder")
+        self.button_load = QPushButton("Charger")
+        self.button_delete = QPushButton("Supprimer")
+        for b in [self.button_new, self.button_save, self.button_load, self.button_delete]:
+            btn_layout.addWidget(b)
+        layout.addLayout(btn_layout)
+        layout.addStretch()
+
+        self.button_new.clicked.connect(self.new_profile)
+        self.button_save.clicked.connect(self.save_profile)
+        self.button_load.clicked.connect(self.load_selected_profile)
+        self.button_delete.clicked.connect(self.delete_profile)
+        self.combo_profiles.currentIndexChanged.connect(self.populate_from_selected)
+
+        self.refresh_profiles()
+
+    # Utility methods
+    def profile_path(self, name: str) -> Path:
+        return self.profile_manager.dir / f"{name}.json"
+
+    def refresh_profiles(self) -> None:
+        self.combo_profiles.blockSignals(True)
+        self.combo_profiles.clear()
+        for f in sorted(self.profile_manager.dir.glob("*.json")):
+            self.combo_profiles.addItem(f.stem)
+        self.combo_profiles.blockSignals(False)
+        if self.combo_profiles.count() > 0:
+            self.combo_profiles.setCurrentIndex(0)
+            self.populate_from_selected()
+
+    def populate_from_selected(self) -> None:
+        name = self.combo_profiles.currentText()
+        if not name:
+            return
+        data = self.profile_manager.load_profile(self.profile_path(name))
+        self.fill_fields(data)
+        if self.checkbox_auto.isChecked():
+            self.profile_manager.apply_profile_to_ui(data, self.main_window)
+
+    def fill_fields(self, data: dict) -> None:
+        self.input_name.setText(data.get("nom", ""))
+        selectors = data.get("selectors", {})
+        self.input_images.setText(selectors.get("images", ""))
+        self.input_desc.setText(selectors.get("description", ""))
+        self.input_collection.setText(selectors.get("collection", ""))
+
+    def new_profile(self) -> None:
+        self.input_name.clear()
+        self.input_images.clear()
+        self.input_desc.clear()
+        self.input_collection.clear()
+
+    def save_profile(self) -> None:
+        name = self.input_name.text().strip()
+        if not name:
+            return
+        data = {
+            "nom": name,
+            "selectors": {
+                "images": self.input_images.text().strip(),
+                "description": self.input_desc.text().strip(),
+                "collection": self.input_collection.text().strip(),
+            },
+        }
+        path = self.profile_path(name)
+        self.profile_manager.save_profile(path, data)
+        self.refresh_profiles()
+
+    def load_selected_profile(self) -> None:
+        name = self.combo_profiles.currentText()
+        if not name:
+            return
+        data = self.profile_manager.load_profile(self.profile_path(name))
+        self.fill_fields(data)
+        self.profile_manager.apply_profile_to_ui(data, self.main_window)
+
+    def delete_profile(self) -> None:
+        name = self.combo_profiles.currentText()
+        if not name:
+            return
+        path = self.profile_path(name)
+        try:
+            path.unlink()
+        except Exception:
+            pass
+        self.refresh_profiles()
 
 
 class PageScrapLienCollection(QWidget):
@@ -612,18 +736,23 @@ class MainWindow(QMainWindow):
         self.settings = settings
         self.setWindowTitle("Interface Py")
 
+        self.profile_manager = SiteProfileManager()
+
         self.menu = QListWidget()
         self.menu.setMaximumWidth(150)
+        self.menu.addItem("Profils")
         self.menu.addItem("Scrap Liens Collection")
         self.menu.addItem("Scraper Images")
         self.menu.addItem("Scrap Description")
         self.menu.addItem("Param\u00e8tres")
 
         self.stack = QStackedWidget()
+        self.page_profiles = PageProfiles(self.profile_manager, self)
         self.page_scrap = PageScrapLienCollection(settings)
         self.page_images = PageScraperImages(settings)
         self.page_desc = PageScrapDescription(settings)
         self.page_settings = PageSettings(settings, self.apply_settings)
+        self.stack.addWidget(self.page_profiles)
         self.stack.addWidget(self.page_scrap)
         self.stack.addWidget(self.page_images)
         self.stack.addWidget(self.page_desc)

--- a/site_profile_manager.py
+++ b/site_profile_manager.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+class SiteProfileManager:
+    """Handle saving/loading of site profiles."""
+
+    def __init__(self, directory: str = "profiles") -> None:
+        self.dir = Path(directory)
+        self.dir.mkdir(exist_ok=True)
+
+    def load_profile(self, path: str | Path) -> Dict[str, Any]:
+        """Return profile data from *path*."""
+        p = Path(path)
+        try:
+            return json.loads(p.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+
+    def save_profile(self, path: str | Path, data: Dict[str, Any]) -> None:
+        """Save *data* into *path* as JSON."""
+        p = Path(path)
+        try:
+            p.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        except Exception:
+            pass
+
+    def apply_profile_to_ui(self, profile: Dict[str, Any], main_window) -> None:
+        """Apply CSS selectors from *profile* to the main window UI."""
+        selectors = profile.get("selectors", {})
+        if hasattr(main_window.page_images, "input_options"):
+            main_window.page_images.input_options.setText(
+                selectors.get("images", "")
+            )
+        if hasattr(main_window.page_desc, "input_selector"):
+            main_window.page_desc.input_selector.setText(
+                selectors.get("description", "")
+            )
+        if hasattr(main_window.page_scrap, "input_selector"):
+            main_window.page_scrap.input_selector.setText(
+                selectors.get("collection", "")
+            )
+


### PR DESCRIPTION
## Summary
- add `SiteProfileManager` helper class to handle JSON profiles
- add `PageProfiles` tab for managing site CSS selectors
- wire new tab in `MainWindow` and update menu order

## Testing
- `python -m py_compile interface_py.py site_profile_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_686920931034833084dab4bd6e009f99