### PR TITLE
Fix missing imports

### DIFF
--- a/interface_py.py
+++ b/interface_py.py
@@ -1,6 +1,7 @@
 import sys
 import logging
 import io
+import os
 from pathlib import Path
 
 from PySide6.QtWidgets import (
@@ -22,6 +23,7 @@ from PySide6.QtWidgets import (
     QSpinBox,
     QFontComboBox,
     QTextEdit,
+    QMessageBox,
 )
 from PySide6.QtCore import (
     QThread,
@@ -31,7 +33,7 @@ from PySide6.QtCore import (
     Property,
     QRect,
 )
-from PySide6.QtGui import QFont, QPainter, QColor, QPixmap
+from PySide6.QtGui import QFont, QPainter, QColor, QPixmap, QClipboard
 
 import scrap_lien_collection
 import scraper_images


### PR DESCRIPTION
## Summary
- add missing `os` import
- include `QMessageBox` and `QClipboard` in Qt imports

## Testing
- `python -m py_compile interface_py.py`

------
https://chatgpt.com/codex/tasks/task_e_68693aeba0f88330b46d1befa0060755