### PR TITLE
sanitize woocommerce image filenames

### DIFF
--- a/scraper_images.py
+++ b/scraper_images.py
@@ -109,7 +109,8 @@ def _handle_image(element, folder: Path, index: int, user_agent: str) -> Path | 
     if src.startswith("//"):
         src = "https:" + src
 
-    filename = os.path.basename(src.split("?")[0])
+    raw_filename = os.path.basename(src.split("?")[0])
+    filename = re.sub(r"-\d+(?=\.\w+$)", "", raw_filename)
     target = folder / filename
     if target.exists():
         return None


### PR DESCRIPTION
## Summary
- fix WooCommerce scraper image filename extraction to strip numeric suffixes

## Testing
- `python -m py_compile scraper_images.py`


------
https://chatgpt.com/codex/tasks/task_e_686941478a948330a31bc4273f668ce2