### PR TITLE
Add alt JSON file support to site profiles

### DIFF
--- a/scraper_images.py
+++ b/scraper_images.py
@@ -224,6 +224,8 @@ def download_images(
     progress_callback: Optional[Callable[[int, int], None]] = None,
     user_agent: str = USER_AGENT,
     use_alt_json: bool = USE_ALT_JSON,
+    *,
+    alt_json_path: str | Path | None = None,
 ) -> dict:
     """Download all images from *url* and return folder and first image."""
     if not url.lower().startswith(("http://", "https://")):
@@ -237,7 +239,11 @@ def download_images(
     downloaded = 0
     skipped = 0
 
-    sentences = _load_alt_sentences() if use_alt_json else {}
+    if use_alt_json:
+        path = Path(alt_json_path) if alt_json_path else ALT_JSON_PATH
+        sentences = _load_alt_sentences(path)
+    else:
+        sentences = {}
     warned_missing: set[str] = set()
 
     try:
@@ -334,6 +340,11 @@ def main() -> None:
         + " le renommage via product_sentences.json",
     )
     parser.add_argument(
+        "--alt-json-path",
+        default=str(ALT_JSON_PATH),
+        help="Chemin du fichier JSON pour le renommage (defaut: %(default)s)",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -371,6 +382,7 @@ def main() -> None:
                 parent_dir=args.parent_dir,
                 user_agent=args.user_agent,
                 use_alt_json=args.use_alt_json,
+                alt_json_path=args.alt_json_path,
             )
             if args.preview:
                 _open_folder(info["folder"])

--- a/settings_manager.py
+++ b/settings_manager.py
@@ -22,6 +22,7 @@ DEFAULT_SETTINGS = {
     "images_file": "",
     "images_dest": "images",
     "images_selector": "",
+    "images_alt_json": "product_sentences.json",
 
     "desc_url": "",
     "desc_selector": "",

--- a/site_profile_manager.py
+++ b/site_profile_manager.py
@@ -33,6 +33,10 @@ class SiteProfileManager:
             main_window.page_images.input_options.setText(
                 selectors.get("images", "")
             )
+        if hasattr(main_window.page_images, "input_alt_json"):
+            main_window.page_images.input_alt_json.setText(
+                profile.get("sentences_file", "")
+            )
         if hasattr(main_window.page_desc, "input_selector"):
             main_window.page_desc.input_selector.setText(
                 selectors.get("description", "")


### PR DESCRIPTION
## Summary
- extend image scraper to accept a custom `product_sentences.json`
- remember ALT JSON file path in settings and profiles
- update profile manager UI to edit ALT JSON field
- load ALT JSON into the images page when a profile is applied

## Testing
- `python -m py_compile scraper_images.py interface_py.py site_profile_manager.py settings_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68697c75ed088330aa5b60f678329e52