### PR TITLE
Hide ALT JSON field in scraper

### DIFF
--- a/interface_py.py
+++ b/interface_py.py
@@ -460,9 +460,13 @@ class PageScraperImages(QWidget):
         self.input_options.hide()
         label_options.hide()
 
-        self.input_alt_json = QLineEdit(manager.settings.get("images_alt_json", "product_sentences.json"))
-        layout.addWidget(QLabel("Fichier ALT JSON"))
-        layout.addWidget(self.input_alt_json)
+        self.input_alt_json = QLineEdit(
+            manager.settings.get("images_alt_json", "product_sentences.json")
+        )
+        # Champ géré via l'onglet Profils – non ajouté au layout
+        label_alt_json = QLabel("Fichier ALT JSON")
+        self.input_alt_json.hide()
+        label_alt_json.hide()
 
         self.checkbox_preview = QCheckBox("Afficher le dossier après téléchargement")
         self.switch_preview = ToggleSwitch()


### PR DESCRIPTION
## Summary
- hide the ALT JSON file field on the scraper images page as it's already managed via profiles

## Testing
- `python -m py_compile interface_py.py`


------
https://chatgpt.com/codex/tasks/task_e_686a669467808330bd10328becfe8c29