### PR TITLE
Add URL file fields in profiles

### DIFF
--- a/interface_py.py
+++ b/interface_py.py
@@ -254,6 +254,14 @@ class PageProfiles(QWidget):
         layout.addWidget(QLabel("Fichier ALT JSON"))
         layout.addWidget(self.input_alt_json)
 
+        self.input_urls_images = QLineEdit()
+        layout.addWidget(QLabel("Fichier URLs Images"))
+        layout.addWidget(self.input_urls_images)
+
+        self.input_urls_desc = QLineEdit()
+        layout.addWidget(QLabel("Fichier URLs Description"))
+        layout.addWidget(self.input_urls_desc)
+
         self.checkbox_auto = QCheckBox("Appliquer automatiquement après chargement")
         layout.addWidget(self.checkbox_auto)
 
@@ -305,6 +313,8 @@ class PageProfiles(QWidget):
         self.input_desc.setText(selectors.get("description", ""))
         self.input_collection.setText(selectors.get("collection", ""))
         self.input_alt_json.setText(data.get("sentences_file", ""))
+        self.input_urls_images.setText(data.get("urls_file", ""))
+        self.input_urls_desc.setText(data.get("desc_urls_file", ""))
 
     def new_profile(self) -> None:
         self.input_name.clear()
@@ -312,6 +322,8 @@ class PageProfiles(QWidget):
         self.input_desc.clear()
         self.input_collection.clear()
         self.input_alt_json.clear()
+        self.input_urls_images.clear()
+        self.input_urls_desc.clear()
 
     def save_profile(self) -> None:
         name = self.input_name.text().strip()
@@ -325,6 +337,8 @@ class PageProfiles(QWidget):
                 "collection": self.input_collection.text().strip(),
             },
             "sentences_file": self.input_alt_json.text().strip(),
+            "urls_file": self.input_urls_images.text().strip(),
+            "desc_urls_file": self.input_urls_desc.text().strip(),
         }
         path = self.profile_path(name)
         self.profile_manager.save_profile(path, data)

--- a/site_profile_manager.py
+++ b/site_profile_manager.py
@@ -37,9 +37,17 @@ class SiteProfileManager:
             main_window.page_images.input_alt_json.setText(
                 profile.get("sentences_file", "")
             )
+        if hasattr(main_window.page_images, "input_urls_file"):
+            main_window.page_images.input_urls_file.setText(
+                profile.get("urls_file", "")
+            )
         if hasattr(main_window.page_desc, "input_selector"):
             main_window.page_desc.input_selector.setText(
                 selectors.get("description", "")
+            )
+        if hasattr(main_window.page_desc, "input_urls_file"):
+            main_window.page_desc.input_urls_file.setText(
+                profile.get("desc_urls_file", "")
             )
         if hasattr(main_window.page_scrap, "input_selector"):
             main_window.page_scrap.input_selector.setText(


### PR DESCRIPTION
## Summary
- allow profiles to store URL list paths
- apply URL paths to image and description pages when loading profiles

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_686a6cd5f19c8330b491ef8d681f0869