### PR TITLE
Add settings example and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 # IDE files
 *.swp
 *.idea/
+settings.json

--- a/README.md
+++ b/README.md
@@ -37,5 +37,15 @@ Installez les bibliothèques nécessaires avec :
 pip install -r requirements.txt
 ```
 
+🔧 Configuration
+
+Lors de la première utilisation, copiez `settings.example.json` en `settings.json` :
+
+```bash
+cp settings.example.json settings.json
+```
+
+Personnalisez ensuite `settings.json` selon vos besoins. Ce fichier est ignoré par Git pour ne pas partager vos réglages personnels.
+
 🗒️ Suivi des audits
 Les rapports d'audit sont enregistrés dans `compte_rendu.txt`. Mettez ce fichier à jour à chaque nouvel audit. Pour consulter les derniers résultats, ouvrez `compte_rendu.txt` ou exécutez `cat compte_rendu.txt` dans votre terminal.

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,0 +1,29 @@
+{
+  "button_bg_color": "#007BFF",
+  "button_text_color": "white",
+  "theme": "light",
+  "button_radius": 8,
+  "lineedit_radius": 6,
+  "console_radius": 6,
+  "font_family": "Consolas",
+  "font_size": 13,
+  "animations": true,
+
+  "scrap_lien_url": "",
+  "scrap_lien_output": "products.txt",
+  "scrap_lien_selector": "",
+
+  "images_url": "",
+  "images_file": "",
+  "images_dest": "images",
+  "images_selector": "",
+  "images_alt_json": "product_sentences.json",
+
+  "desc_url": "",
+  "desc_selector": "",
+  "desc_output": "description.html",
+
+  "linkgen_base_url": "https://www.planetebob.fr",
+  "linkgen_date": "2025/07",
+  "linkgen_folder": ""
+}


### PR DESCRIPTION
## Summary
- ignore user-specific `settings.json`
- provide `settings.example.json` with default values
- document how to copy the example settings file on first use

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686aa6d03a548330a1b9b634f12c8cbe