### PR TITLE
Add pytest infrastructure and basic unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,9 @@ Personnalisez ensuite `settings.json` selon vos besoins. Ce fichier est ignoré 
 
 🗒️ Suivi des audits
 Les rapports d'audit sont enregistrés dans `compte_rendu.txt`. Mettez ce fichier à jour à chaque nouvel audit. Pour consulter les derniers résultats, ouvrez `compte_rendu.txt` ou exécutez `cat compte_rendu.txt` dans votre terminal.
+
+🧪 Tests unitaires
+Après installation des dépendances, lancez simplement :
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tqdm
 requests
 beautifulsoup4
 PySide6
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+import sys
+import types
+
+# Provide minimal fake selenium and webdriver_manager modules so that
+# project modules can be imported without the real dependencies.
+selenium = types.ModuleType("selenium")
+webdriver_mod = types.ModuleType("webdriver")
+selenium.webdriver = webdriver_mod
+sys.modules.setdefault("selenium", selenium)
+sys.modules.setdefault("selenium.webdriver", webdriver_mod)
+
+# webdriver.common.by
+common_mod = types.ModuleType("common")
+by_mod = types.ModuleType("by")
+by_mod.By = types.SimpleNamespace(CSS_SELECTOR="CSS")
+webdriver_mod.common = common_mod
+common_mod.by = by_mod
+sys.modules.setdefault("selenium.webdriver.common", common_mod)
+sys.modules.setdefault("selenium.webdriver.common.by", by_mod)
+
+# webdriver.support
+support_mod = types.ModuleType("support")
+ui_mod = types.ModuleType("ui")
+ui_mod.WebDriverWait = object
+ec_mod = types.ModuleType("expected_conditions")
+webdriver_mod.support = support_mod
+support_mod.ui = ui_mod
+support_mod.expected_conditions = ec_mod
+sys.modules.setdefault("selenium.webdriver.support", support_mod)
+sys.modules.setdefault("selenium.webdriver.support.ui", ui_mod)
+sys.modules.setdefault("selenium.webdriver.support.expected_conditions", ec_mod)
+
+# webdriver.chrome
+chrome_mod = types.ModuleType("chrome")
+options_mod = types.ModuleType("options")
+options_mod.Options = object
+service_mod = types.ModuleType("service")
+service_mod.Service = object
+chrome_mod.options = options_mod
+chrome_mod.service = service_mod
+webdriver_mod.chrome = chrome_mod
+sys.modules.setdefault("selenium.webdriver.chrome", chrome_mod)
+sys.modules.setdefault("selenium.webdriver.chrome.options", options_mod)
+sys.modules.setdefault("selenium.webdriver.chrome.service", service_mod)
+
+# webdriver_manager.chrome
+wm_mod = types.ModuleType("webdriver_manager.chrome")
+class DummyCDM:
+    def install(self):
+        return "/tmp/chromedriver"
+wm_mod.ChromeDriverManager = DummyCDM
+sys.modules.setdefault("webdriver_manager.chrome", wm_mod)
+
+# Dummy requests and tqdm modules
+requests_mod = types.ModuleType("requests")
+sys.modules.setdefault("requests", requests_mod)
+
+tqdm_mod = types.ModuleType("tqdm")
+tqdm_mod.tqdm = lambda x, **k: x
+sys.modules.setdefault("tqdm", tqdm_mod)
+
+# Ensure project root is on sys.path for module imports
+from pathlib import Path
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -1,0 +1,49 @@
+from importlib import util
+from pathlib import Path
+
+spec = util.spec_from_file_location(
+    "scrap_description_produit",
+    Path(__file__).resolve().parents[1] / "scrap_description_produit.py",
+)
+sdp = util.module_from_spec(spec)
+spec.loader.exec_module(sdp)
+
+
+class DummyElement:
+    def get_attribute(self, name):
+        return "  <p>desc</p>  " if name == "innerHTML" else None
+
+
+class DummyDriver:
+    def get(self, url):
+        self.url = url
+
+    def find_element(self, by, value):
+        return DummyElement()
+
+    def quit(self):
+        self.closed = True
+
+
+class DummyWait:
+    def __init__(self, driver, timeout):
+        pass
+
+    def until(self, condition):
+        return True
+
+
+class DummyEC:
+    @staticmethod
+    def presence_of_element_located(locator):
+        return lambda d: True
+
+
+def test_extract_html_description(monkeypatch):
+    monkeypatch.setattr(sdp, "WebDriverWait", DummyWait)
+    monkeypatch.setattr(sdp, "EC", DummyEC)
+    monkeypatch.setattr("driver_utils.setup_driver", lambda: DummyDriver())
+    monkeypatch.setattr(sdp, "setup_driver", lambda: DummyDriver())
+
+    html = sdp.extract_html_description("https://example.com", "div")
+    assert html == "<p>desc</p>"

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,42 @@
+from importlib import util
+from pathlib import Path
+
+spec = util.spec_from_file_location(
+    "scraper_images",
+    Path(__file__).resolve().parents[1] / "scraper_images.py",
+)
+si = util.module_from_spec(spec)
+spec.loader.exec_module(si)
+
+
+class ElementBase64:
+    def get_attribute(self, name):
+        if name == "src":
+            return "data:image/png;base64,aGVsbG8="
+        return None
+
+
+class ElementURL:
+    def get_attribute(self, name):
+        if name == "src":
+            return "https://example.com/img/test.png?x=1"
+        return None
+
+
+def test_handle_image_base64(tmp_path):
+    elem = ElementBase64()
+    path = si._handle_image(elem, tmp_path, 1, "UA")
+    assert path.exists()
+    assert path.read_bytes() == b"hello"
+
+
+def test_handle_image_url(tmp_path, monkeypatch):
+    elem = ElementURL()
+
+    def fake_download(url, dest, ua):
+        dest.write_bytes(b"data")
+
+    monkeypatch.setattr(si, "_download_binary", fake_download)
+    path = si._handle_image(elem, tmp_path, 1, "UA")
+    assert path.exists()
+    assert path.name == "test.png"


### PR DESCRIPTION
## Summary
- add pytest dependency
- create simple unit tests for description extraction and image handling
- document how to run the test suite
- add helper `conftest.py` to provide stub modules for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa832249c8330a47409eab80229c7