### PR TITLE
Handle data-src attributes

### DIFF
--- a/scraper_images.py
+++ b/scraper_images.py
@@ -276,7 +276,11 @@ def download_images(
                         first_image = saved
                 else:
                     skipped += 1
-                WebDriverWait(driver, 5).until(lambda d: img.get_attribute("src"))
+                WebDriverWait(driver, 5).until(
+                    lambda d: img.get_attribute("src")
+                    or img.get_attribute("data-src")
+                    or img.get_attribute("data-srcset")
+                )
                 if progress_callback:
                     progress_callback(idx, total)
             except Exception as exc:

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -40,3 +40,66 @@ def test_handle_image_url(tmp_path, monkeypatch):
     path = si._handle_image(elem, tmp_path, 1, "UA")
     assert path.exists()
     assert path.name == "test.png"
+
+
+class ElementDataSrc:
+    def get_attribute(self, name):
+        if name == "data-src":
+            return "https://example.com/img/ds.png"
+        return None
+
+
+class DummyDriver:
+    def __init__(self, elems):
+        self.elems = elems
+
+    def get(self, url):
+        self.url = url
+
+    def find_elements(self, by, selector):
+        return self.elems
+
+    def quit(self):
+        self.closed = True
+
+
+class DummyWait:
+    def __init__(self, driver, timeout):
+        self.driver = driver
+
+    def until(self, condition):
+        return condition(self.driver)
+
+
+class DummyEC:
+    @staticmethod
+    def presence_of_element_located(locator):
+        return lambda d: True
+
+
+def test_download_images_datasrc_progress(tmp_path, monkeypatch):
+    elem = ElementDataSrc()
+    driver = DummyDriver([elem])
+
+    monkeypatch.setattr(si, "WebDriverWait", DummyWait)
+    monkeypatch.setattr(si, "EC", DummyEC)
+    monkeypatch.setattr("driver_utils.setup_driver", lambda: driver)
+    monkeypatch.setattr(si, "setup_driver", lambda: driver)
+    monkeypatch.setattr(si, "_find_product_name", lambda d: "prod")
+
+    def fake_download(url, dest, ua):
+        dest.write_bytes(b"img")
+
+    monkeypatch.setattr(si, "_download_binary", fake_download)
+
+    calls = []
+
+    si.download_images(
+        "http://example.com",
+        css_selector="img",
+        parent_dir=tmp_path,
+        progress_callback=lambda i, t: calls.append((i, t)),
+        use_alt_json=False,
+    )
+
+    assert calls == [(1, 1)]


### PR DESCRIPTION
## Summary
- extend wait logic when scraping images to look for src, data-src or data-srcset
- ensure progress callbacks trigger on images that only use data-src
- add unit test covering the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aad6779d083309d8f33d4b006598c