### PR TITLE
Modern UI skeleton with sidebar and toolbar

### DIFF
--- a/style.qss
+++ b/style.qss
@@ -1,0 +1,38 @@
+/* Modern dark theme */
+QMainWindow {
+    background-color: #2c2c2c;
+    color: #dddddd;
+    font-family: "Segoe UI", "Inter", "Roboto", sans-serif;
+}
+
+QToolBar {
+    background-color: #1e1e1e;
+    padding: 4px;
+    spacing: 8px;
+}
+
+QToolButton {
+    background: transparent;
+    border: none;
+    color: #dddddd;
+    padding: 6px 12px;
+}
+QToolButton:checked, QToolButton:hover {
+    background-color: #3c3f41;
+    color: #6fa8dc;
+}
+
+QLineEdit, QPlainTextEdit, QTextEdit {
+    background-color: #3c3c3c;
+    color: #dddddd;
+    border: 1px solid #444444;
+}
+
+QProgressBar {
+    height: 16px;
+    border: 1px solid #444444;
+    background-color: #3c3c3c;
+}
+QProgressBar::chunk {
+    background-color: #6fa8dc;
+}


### PR DESCRIPTION
## Summary
- add load_stylesheet helper
- redesign `MainWindow` to use modern sidebar with `QToolButton`
- add a toolbar containing page title and search field
- apply stylesheet from new `style.qss`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb47bd5e08330af9526f9b3853355