### PR TITLE
Add variant image scraping

### DIFF
--- a/moteur_variante.py
+++ b/moteur_variante.py
@@ -1,6 +1,9 @@
 """Extract product variants from a web page."""
 from __future__ import annotations
 
+import random
+import time
+
 import argparse
 import logging
 from pathlib import Path
@@ -35,11 +38,67 @@ def extract_variants(url: str, selector: str = DEFAULT_SELECTOR) -> tuple[str, l
         driver.quit()
 
 
+def extract_variants_with_images(url: str) -> tuple[str, dict[str, str]]:
+    """Return product title and a mapping of variant name to image URL."""
+    if not url.lower().startswith(("http://", "https://")):
+        raise ValueError("URL must start with http:// or https://")
+
+    driver = setup_driver()
+    try:
+        logging.info("\U0001F310 Chargement de la page %s", url)
+        driver.get(url)
+        wait = WebDriverWait(driver, 10)
+        wait.until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "h1"))
+        )
+        title = driver.find_element(By.CSS_SELECTOR, "h1").text.strip()
+
+        container = driver.find_element(By.CSS_SELECTOR, ".variant-picker__option-values")
+        inputs = container.find_elements(By.CSS_SELECTOR, "input[type='radio'].sr-only")
+
+        results: dict[str, str] = {}
+        for inp in inputs:
+            name = inp.get_attribute("value")
+            if not name or name in results:
+                continue
+
+            img_elem = driver.find_element(By.CSS_SELECTOR, ".product-gallery__media.is-selected img")
+            old_src = img_elem.get_attribute("src")
+
+            if inp.get_attribute("checked") is None:
+                driver.execute_script("arguments[0].click();", inp)
+                time.sleep(random.uniform(0.1, 0.2))
+                WebDriverWait(driver, 5).until(
+                    lambda d: d.find_element(By.CSS_SELECTOR, ".product-gallery__media.is-selected img").get_attribute("src") != old_src
+                )
+                img_elem = driver.find_element(By.CSS_SELECTOR, ".product-gallery__media.is-selected img")
+
+            src = img_elem.get_attribute("src")
+            if src.startswith("//"):
+                src = "https:" + src
+            results[name] = src
+            logging.info("%s -> %s", name, src)
+
+        return title, results
+    finally:
+        driver.quit()
+
+
 def save_to_file(title: str, variants: list[str], path: Path) -> None:
     """Write *title* and *variants* into *path* as a single line."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as fh:
         fh.write(f"{title}\t{', '.join(variants)}\n")
+    logging.info("\U0001F4BE Variantes enregistr\u00e9es dans %s", path)
+
+
+def save_images_to_file(title: str, variants: dict[str, str], path: Path) -> None:
+    """Write *title* and variant/image pairs into *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write(f"{title}\n")
+        for name, img in variants.items():
+            fh.write(f"{name} : {img}\n")
     logging.info("\U0001F4BE Variantes enregistr\u00e9es dans %s", path)
 
 

--- a/tests/test_variantes.py
+++ b/tests/test_variantes.py
@@ -47,3 +47,95 @@ def test_extract_variants(monkeypatch):
     mv.save_to_file(title, variants, tmp)
     assert tmp.read_text(encoding="utf-8").strip() == "Title\tRed, Blue"
     tmp.unlink()
+
+
+class DummyVariantInput:
+    def __init__(self, value, src, selected=False):
+        self._value = value
+        self._src = src
+        self._selected = selected
+
+    def get_attribute(self, name):
+        if name == "value":
+            return self._value
+        if name == "checked":
+            return "true" if self._selected else None
+
+    def click(self):
+        self._selected = True
+
+
+class DummyImage:
+    def __init__(self, src):
+        self.src = src
+
+    def get_attribute(self, name):
+        if name == "src":
+            return self.src
+
+
+class DummyVariantContainer:
+    def __init__(self, inputs):
+        self.inputs = inputs
+
+    def find_elements(self, by, value):
+        return self.inputs
+
+
+class DummyDriverImages:
+    def __init__(self):
+        self.closed = False
+        self.inputs = [
+            DummyVariantInput("Red", "red.png", selected=True),
+            DummyVariantInput("Blue", "blue.png"),
+        ]
+        self.image = DummyImage("red.png")
+        self.container = DummyVariantContainer(self.inputs)
+
+    def get(self, url):
+        self.url = url
+
+    def find_element(self, by, value):
+        if value == "h1":
+            return DummyElem("Title")
+        if value == ".variant-picker__option-values":
+            return self.container
+        if value == ".product-gallery__media.is-selected img":
+            return self.image
+
+    def execute_script(self, script, elem):
+        self.image.src = elem._src
+        elem.click()
+
+    def quit(self):
+        self.closed = True
+
+
+class DummyWait2:
+    def __init__(self, driver, timeout):
+        self.driver = driver
+
+    def until(self, cond):
+        return cond(self.driver)
+
+
+def test_extract_variants_with_images(monkeypatch):
+    driver = DummyDriverImages()
+    monkeypatch.setattr(mv, "WebDriverWait", DummyWait2)
+    monkeypatch.setattr(mv, "EC", DummyEC)
+    monkeypatch.setattr("driver_utils.setup_driver", lambda: driver)
+    monkeypatch.setattr(mv, "setup_driver", lambda: driver)
+    monkeypatch.setattr(mv.time, "sleep", lambda x: None)
+
+    title, mapping = mv.extract_variants_with_images("https://example.com")
+    assert title == "Title"
+    assert mapping == {"Red": "red.png", "Blue": "blue.png"}
+
+    tmp = Path("tmp_images.txt")
+    mv.save_images_to_file(title, mapping, tmp)
+    assert tmp.read_text(encoding="utf-8").strip().splitlines() == [
+        "Title",
+        "Red : red.png",
+        "Blue : blue.png",
+    ]
+    tmp.unlink()


### PR DESCRIPTION
## Summary
- support variant image extraction in `moteur_variante`
- handle saving of variant images to file
- unit tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d05260e208330b39be12778424d9e