### PR TITLE
Log profile load/save errors

### DIFF
--- a/site_profile_manager.py
+++ b/site_profile_manager.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict
 
@@ -15,7 +16,8 @@ class SiteProfileManager:
         p = Path(path)
         try:
             return json.loads(p.read_text(encoding="utf-8"))
-        except Exception:
+        except Exception as exc:
+            logging.warning("Failed to load profile %s: %s", path, exc)
             return {}
 
     def save_profile(self, path: str | Path, data: Dict[str, Any]) -> None:
@@ -23,8 +25,8 @@ class SiteProfileManager:
         p = Path(path)
         try:
             p.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.warning("Failed to save profile %s: %s", path, exc)
 
     def apply_profile_to_ui(self, profile: Dict[str, Any], main_window) -> None:
         """Apply CSS selectors from *profile* to the main window UI."""

--- a/tests/test_site_profile_manager.py
+++ b/tests/test_site_profile_manager.py
@@ -1,0 +1,16 @@
+import logging
+from pathlib import Path
+
+from site_profile_manager import SiteProfileManager
+
+
+def test_load_profile_logs_warning(tmp_path, caplog):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ bad json }", encoding="utf-8")
+
+    spm = SiteProfileManager(tmp_path)
+    with caplog.at_level(logging.WARNING):
+        data = spm.load_profile(bad)
+
+    assert data == {}
+    assert any("Failed to load profile" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- log failures when loading or saving site profiles
- add unit test covering error logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6a2bc79883308995b03b0e0079ca