### PR TITLE
Add WP image filename cleaning

### DIFF
--- a/alpha_engine.py
+++ b/alpha_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from PySide6.QtWidgets import (
     QWidget,
@@ -83,6 +84,7 @@ class AlphaEngine(QWidget):
     def _build_wp_url(domain: str, date_path: str, img_url: str) -> str:
         """Return WordPress URL for *img_url* using domain and date."""
         filename = img_url.split("/")[-1].split("?")[0]
+        filename = re.sub(r"-\d+(?=\.\w+$)", "", filename)
         domain = domain.rstrip("/")
         date_path = date_path.strip("/")
         return f"{domain}/wp-content/uploads/{date_path}/{filename}"

--- a/tests/test_alpha_engine.py
+++ b/tests/test_alpha_engine.py
@@ -182,3 +182,18 @@ def test_start_analysis_error(monkeypatch):
     eng.start_analysis()
 
     assert mod.QMessageBox.last[-1] == ("critical", "Erreur", "boom")
+
+
+def test_build_wp_url_strip_digits(monkeypatch):
+    mod = load_module(monkeypatch)
+
+    url = mod.AlphaEngine._build_wp_url(
+        "https://wp",
+        "2024/05",
+        "https://ex.com/img/bob-ficelle-outdoor-beige-453.png?x=1",
+    )
+
+    assert (
+        url
+        == "https://wp/wp-content/uploads/2024/05/bob-ficelle-outdoor-beige.png"
+    )


### PR DESCRIPTION
## Summary
- sanitize image filenames in `AlphaEngine._build_wp_url`
- test that `_build_wp_url` removes trailing numeric IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d74faed488330b73915d40507d42e