### PR TITLE
Remove webdriver import

### DIFF
--- a/scrap_description_produit.py
+++ b/scrap_description_produit.py
@@ -7,7 +7,6 @@ import argparse
 import logging
 from pathlib import Path
 
-from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC

--- a/scraper_images.py
+++ b/scraper_images.py
@@ -44,6 +44,9 @@ USE_ALT_JSON = True
 
 logger = logging.getLogger(__name__)
 
+# Reserved paths to avoid name collisions during concurrent downloads
+_RESERVED_PATHS: set[Path] = set()
+
 
 def _safe_folder(product_name: str, base_dir: Path | str = "images") -> Path:
     """Return a Path object for the folder where images will be saved."""
@@ -101,9 +104,10 @@ def _unique_path(folder: Path, filename: str) -> Path:
     base, ext = os.path.splitext(filename)
     candidate = folder / filename
     counter = 1
-    while candidate.exists():
+    while candidate.exists() or candidate in _RESERVED_PATHS:
         candidate = folder / f"{base}_{counter}{ext}"
         counter += 1
+    _RESERVED_PATHS.add(candidate)
     return candidate
 
 


### PR DESCRIPTION
## Summary
- remove unused webdriver import from `scrap_description_produit.py`
- ensure image downloads don't collide in concurrent mode by reserving paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e345986448330b3cbd26b990c60b2