### PR TITLE
Add configurable driver path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Adaptez ensuite `settings.json` en fonction de vos préférences. Ce fichier de 
 🔄 Mise à jour de l'application
 Un bouton "Mettre à jour l'app" exécute `git pull` puis redémarre le programme. L'opération nécessite une connexion réseau et peut entraîner des conflits si vous avez modifié le code localement. Une confirmation est demandée avant l'exécution et les erreurs réseau sont affichées clairement. Vous pouvez désactiver cette fonctionnalité en plaçant `"enable_update": false` dans `settings.json`.
 
+🛜 Mode hors-ligne
+Si votre machine n'a pas accès à internet, renseignez le chemin vers un ChromeDriver déjà installé en local via la clé `"driver_path"` de `settings.json`. L'application utilisera alors ce binaire au lieu de tenter un téléchargement automatique.
+
 🗒️ Suivi des audits
 Les rapports d'audit sont enregistrés dans `compte_rendu.txt`. Mettez ce fichier à jour à chaque nouvel audit. Pour consulter les derniers résultats, ouvrez `compte_rendu.txt` ou exécutez `cat compte_rendu.txt` dans votre terminal.
 

--- a/interface_py.py
+++ b/interface_py.py
@@ -1137,6 +1137,10 @@ class PageSettings(QWidget):
         self.checkbox_update.setChecked(manager.settings.get("enable_update", True))
         layout.addWidget(self.checkbox_update)
 
+        self.input_driver_path = QLineEdit(manager.settings.get("driver_path", ""))
+        layout.addWidget(QLabel("Chemin ChromeDriver"))
+        layout.addWidget(self.input_driver_path)
+
         self.button_reset = QPushButton("R\u00e9initialiser les param\u00e8tres")
         layout.addWidget(self.button_reset)
 
@@ -1156,6 +1160,7 @@ class PageSettings(QWidget):
             self.spin_font_size,
             self.checkbox_anim,
             self.checkbox_update,
+            self.input_driver_path,
         ]:
             if isinstance(w, QLineEdit):
                 w.editingFinished.connect(self.update_settings)
@@ -1183,6 +1188,7 @@ class PageSettings(QWidget):
         s["font_size"] = self.spin_font_size.value()
         s["animations"] = self.checkbox_anim.isChecked()
         s["enable_update"] = self.checkbox_update.isChecked()
+        s["driver_path"] = self.input_driver_path.text().strip()
         self.manager.save()
         self.apply_cb()
 
@@ -1198,6 +1204,7 @@ class PageSettings(QWidget):
         self.spin_font_size.setValue(self.manager.settings["font_size"])
         self.checkbox_anim.setChecked(self.manager.settings["animations"])
         self.checkbox_update.setChecked(self.manager.settings.get("enable_update", True))
+        self.input_driver_path.setText(self.manager.settings.get("driver_path", ""))
         self.manager.save()
         self.apply_cb()
 

--- a/settings.example.json
+++ b/settings.example.json
@@ -9,6 +9,7 @@
   "font_size": 13,
   "animations": true,
   "enable_update": true,
+  "driver_path": "",
 
   "scrap_lien_url": "",
   "scrap_lien_output": "products.txt",

--- a/settings_manager.py
+++ b/settings_manager.py
@@ -13,6 +13,7 @@ DEFAULT_SETTINGS = {
     "font_size": 13,
     "animations": True,
     "enable_update": True,
+    "driver_path": "",
 
     # Last used values for scrapers
     "scrap_lien_url": "",

--- a/tests/test_driver_utils.py
+++ b/tests/test_driver_utils.py
@@ -1,0 +1,71 @@
+import importlib
+from pathlib import Path
+
+import driver_utils
+
+class DummyOptions:
+    def __init__(self):
+        self.args = []
+    def add_argument(self, arg):
+        self.args.append(arg)
+    def add_experimental_option(self, name, value):
+        pass
+
+
+def test_setup_driver_with_path(tmp_path, monkeypatch):
+    chromedriver = tmp_path / "chromedriver"
+    chromedriver.write_text("bin")
+
+    calls = {}
+
+    class DummyService:
+        def __init__(self, path):
+            calls["path"] = path
+
+    class DummyDriver:
+        def execute_cdp_cmd(self, *a, **k):
+            pass
+
+    class DummyCDM:
+        def install(self):
+            calls["install"] = True
+            return "/tmp/cd"
+
+    monkeypatch.setattr(driver_utils, "Service", DummyService)
+    monkeypatch.setattr(driver_utils, "Options", DummyOptions)
+    monkeypatch.setattr(driver_utils.webdriver, "Chrome", lambda service, options: DummyDriver(), raising=False)
+    monkeypatch.setattr(driver_utils, "ChromeDriverManager", DummyCDM)
+
+    driver = driver_utils.setup_driver(driver_path=str(chromedriver))
+
+    assert isinstance(driver, DummyDriver)
+    assert calls["path"] == str(chromedriver)
+    assert "install" not in calls
+
+
+def test_setup_driver_download(monkeypatch):
+    calls = {}
+
+    class DummyService:
+        def __init__(self, path):
+            calls["path"] = path
+
+    class DummyCDM:
+        def install(self):
+            calls["install"] = True
+            return "/tmp/cd"
+
+    class DummyDriver:
+        def execute_cdp_cmd(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(driver_utils, "Service", DummyService)
+    monkeypatch.setattr(driver_utils, "Options", DummyOptions)
+    monkeypatch.setattr(driver_utils, "ChromeDriverManager", DummyCDM)
+    monkeypatch.setattr(driver_utils.webdriver, "Chrome", lambda service, options: DummyDriver(), raising=False)
+
+    driver = driver_utils.setup_driver(driver_path="/does/not/exist")
+
+    assert isinstance(driver, DummyDriver)
+    assert calls["install"] is True
+    assert calls["path"] == "/tmp/cd"


### PR DESCRIPTION
## Summary
- allow providing a webdriver path in `driver_utils.setup_driver`
- store webdriver path in settings and show it in the GUI
- document offline mode in README
- add example field in `settings.example.json`
- test driver_utils paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e433e1018833087094e2578b15344