### PR TITLE
Add automatic profile detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Un outil Python robuste et évolutif pour scraper automatiquement les images de 
 ✅ Extraction des noms et liens de produits d'une collection (scrap_lien_collection.py)
 ✅ Récupération de la description HTML d'un produit (scrap_description_produit.py)
 ✅ Nouvel onglet "Alpha" combinant variantes et liens WordPress
+✅ Profil par défaut appliqué automatiquement si l'URL correspond à Shopify ou WooCommerce
 Exemple : `python scrap_lien_collection.py https://exemple.com/collection --selector "div.product a"`
 
 ### Utilisation du scraper d'images

--- a/interface_py.py
+++ b/interface_py.py
@@ -1314,6 +1314,17 @@ class MainWindow(QMainWindow):
         self.stack.addWidget(self.page_alpha)
         self.stack.addWidget(self.page_settings)
 
+        self.page_images.input_source.editingFinished.connect(
+            lambda: self.profile_manager.detect_and_apply(
+                self.page_images.input_source.text(), self
+            )
+        )
+        self.page_scrap.input_url.editingFinished.connect(
+            lambda: self.profile_manager.detect_and_apply(
+                self.page_scrap.input_url.text(), self
+            )
+        )
+
         self.stack.currentChanged.connect(self.update_title)
 
         # Layout central

--- a/profiles/shopify_default.json
+++ b/profiles/shopify_default.json
@@ -1,0 +1,8 @@
+{
+  "nom": "Shopify Default",
+  "selectors": {
+    "images": ".product-gallery__media-list img",
+    "description": ".rte",
+    "collection": "div.product-card__info h3.product-card__title a"
+  }
+}

--- a/profiles/woocommerce_default.json
+++ b/profiles/woocommerce_default.json
@@ -1,0 +1,8 @@
+{
+  "nom": "WooCommerce Default",
+  "selectors": {
+    "images": ".woocommerce-product-gallery__image img",
+    "description": ".woocommerce-Tabs-panel--description",
+    "collection": "li.product a.woocommerce-LoopProduct-link"
+  }
+}

--- a/site_profile_manager.py
+++ b/site_profile_manager.py
@@ -2,6 +2,7 @@ import json
 import logging
 from pathlib import Path
 from typing import Any, Dict
+from urllib.parse import urlparse
 
 
 class SiteProfileManager:
@@ -55,4 +56,24 @@ class SiteProfileManager:
             main_window.page_scrap.input_selector.setText(
                 selectors.get("collection", "")
             )
+
+    def detect_and_apply(self, url: str, main_window) -> None:
+        """Detect site type from *url* and apply matching default profile."""
+        if not url:
+            return
+        host = urlparse(url).netloc.lower()
+        profile_name = None
+        if "shopify" in host:
+            profile_name = "shopify_default.json"
+        elif any(key in host for key in ["woocommerce", "wordpress", "wp"]):
+            profile_name = "woocommerce_default.json"
+
+        if not profile_name:
+            return
+
+        path = self.dir / profile_name
+        if not path.exists():
+            return
+        data = self.load_profile(path)
+        self.apply_profile_to_ui(data, main_window)
 

--- a/tests/test_site_profile_manager.py
+++ b/tests/test_site_profile_manager.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from pathlib import Path
 
 from site_profile_manager import SiteProfileManager
@@ -14,3 +15,38 @@ def test_load_profile_logs_warning(tmp_path, caplog):
 
     assert data == {}
     assert any("Failed to load profile" in record.message for record in caplog.records)
+
+
+def test_detect_and_apply(tmp_path):
+    woo = {"selectors": {"images": "wooimg", "description": "woodesc", "collection": "woocol"}}
+    shop = {"selectors": {"images": "shopimg", "description": "shopdesc", "collection": "shopcol"}}
+    (tmp_path / "woocommerce_default.json").write_text(json.dumps(woo), encoding="utf-8")
+    (tmp_path / "shopify_default.json").write_text(json.dumps(shop), encoding="utf-8")
+
+    spm = SiteProfileManager(tmp_path)
+
+    class Field:
+        def __init__(self):
+            self.text = ""
+
+        def setText(self, val):
+            self.text = val
+
+    class Dummy:
+        pass
+
+    class DummyWin:
+        def __init__(self):
+            self.page_images = Dummy()
+            self.page_images.input_options = Field()
+            self.page_desc = Dummy()
+            self.page_desc.input_selector = Field()
+            self.page_scrap = Dummy()
+            self.page_scrap.input_selector = Field()
+
+    mw = DummyWin()
+    spm.detect_and_apply("https://example.myshopify.com", mw)
+    assert mw.page_images.input_options.text == "shopimg"
+    mw2 = DummyWin()
+    spm.detect_and_apply("https://example.com", mw2)
+    assert mw2.page_images.input_options.text == ""


### PR DESCRIPTION
## Summary
- create default profiles for Shopify and WooCommerce
- add method to detect the site type and auto-load profiles
- connect URL inputs to auto detection in the UI
- describe feature in README
- test auto detection logic

## Testing
- `pytest -q` *(fails: command not found)*
- `pip install pytest` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686e46ce1d748330acda223b0d0d567e