### PR TITLE
Revamp Alpha2 UI

### DIFF
--- a/tests/test_images_worker.py
+++ b/tests/test_images_worker.py
@@ -18,8 +18,8 @@ def setup_pyside(monkeypatch):
         "QApplication","QMainWindow","QWidget","QListWidget","QStackedWidget",
         "QHBoxLayout","QVBoxLayout","QLineEdit","QComboBox","QPushButton",
         "QPlainTextEdit","QLabel","QProgressBar","QFileDialog","QCheckBox",
-        "QSpinBox","QFontComboBox","QTextEdit","QMessageBox","QToolBar",
-        "QToolButton","QScrollArea","QSizePolicy","QFrame",
+        "QSpinBox","QFontComboBox","QTextEdit","QGroupBox","QMessageBox",
+        "QToolBar","QToolButton","QScrollArea","QSizePolicy","QFrame",
     ]:
         setattr(qtwidgets, name, type(name, (), {}))
 

--- a/tests/test_variant_worker.py
+++ b/tests/test_variant_worker.py
@@ -18,8 +18,8 @@ def setup_pyside(monkeypatch):
         "QApplication","QMainWindow","QWidget","QListWidget","QStackedWidget",
         "QHBoxLayout","QVBoxLayout","QLineEdit","QComboBox","QPushButton",
         "QPlainTextEdit","QLabel","QProgressBar","QFileDialog","QCheckBox",
-        "QSpinBox","QFontComboBox","QTextEdit","QMessageBox","QToolBar",
-        "QToolButton","QScrollArea","QSizePolicy","QFrame",
+        "QSpinBox","QFontComboBox","QTextEdit","QGroupBox","QMessageBox",
+        "QToolBar","QToolButton","QScrollArea","QSizePolicy","QFrame",
     ]:
         setattr(qtwidgets, name, type(name, (), {}))
 


### PR DESCRIPTION
## Summary
- add new `Alpha2Widget` with grouped UI sections
- show progress while scraping images then variants sequentially
- enable Excel export for variant results
- include `VariantFetchWorker` for fetching variants asynchronously
- update tests for dummy `QGroupBox`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e65eb57e48330a7689c819b80340b