### PR TITLE
Add customizable user-agent setting

### DIFF
--- a/interface_py.py
+++ b/interface_py.py
@@ -1502,6 +1502,12 @@ class PageSettings(QWidget):
         layout.addWidget(QLabel("Chemin ChromeDriver"))
         layout.addWidget(self.input_driver_path)
 
+        self.input_user_agent = QLineEdit(
+            manager.settings.get("user_agent", scraper_images.USER_AGENT)
+        )
+        layout.addWidget(QLabel("User-Agent"))
+        layout.addWidget(self.input_user_agent)
+
         self.button_reset = QPushButton("R\u00e9initialiser les param\u00e8tres")
         layout.addWidget(self.button_reset)
 
@@ -1523,6 +1529,7 @@ class PageSettings(QWidget):
             self.checkbox_update,
             self.checkbox_headless,
             self.input_driver_path,
+            self.input_user_agent,
         ]:
             if isinstance(w, QLineEdit):
                 w.editingFinished.connect(self.update_settings)
@@ -1552,7 +1559,9 @@ class PageSettings(QWidget):
         s["enable_update"] = self.checkbox_update.isChecked()
         s["headless"] = self.checkbox_headless.isChecked()
         s["driver_path"] = self.input_driver_path.text().strip()
+        s["user_agent"] = self.input_user_agent.text().strip() or scraper_images.USER_AGENT
         self.manager.save_setting("headless", s["headless"])
+        self.manager.save_setting("user_agent", s["user_agent"])
         self.manager.save()
         self.apply_cb()
 
@@ -1570,6 +1579,9 @@ class PageSettings(QWidget):
         self.checkbox_update.setChecked(self.manager.settings.get("enable_update", True))
         self.checkbox_headless.setChecked(self.manager.settings.get("headless", True))
         self.input_driver_path.setText(self.manager.settings.get("driver_path", ""))
+        self.input_user_agent.setText(
+            self.manager.settings.get("user_agent", scraper_images.USER_AGENT)
+        )
         self.manager.save()
         self.apply_cb()
 

--- a/scraper_images.py
+++ b/scraper_images.py
@@ -248,7 +248,7 @@ def download_images(
     css_selector: str = DEFAULT_CSS_SELECTOR,
     parent_dir: Path | str = "images",
     progress_callback: Optional[Callable[[int, int], None]] = None,
-    user_agent: str = USER_AGENT,
+    user_agent: str | None = None,
     use_alt_json: bool = USE_ALT_JSON,
     *,
     alt_json_path: str | Path | None = None,
@@ -256,6 +256,16 @@ def download_images(
 ) -> dict:
     """Download all images from *url* and return folder and first image."""
     _RESERVED_PATHS.clear()
+    if user_agent is None:
+        try:
+            path = Path("settings.json")
+            if path.is_file():
+                data = json.loads(path.read_text(encoding="utf-8"))
+                user_agent = data.get("user_agent", USER_AGENT)
+            else:
+                user_agent = USER_AGENT
+        except Exception:
+            user_agent = USER_AGENT
     if not url.lower().startswith(("http://", "https://")):
         raise ValueError("URL must start with http:// or https://")
 

--- a/settings.example.json
+++ b/settings.example.json
@@ -10,6 +10,7 @@
   "animations": true,
   "enable_update": true,
   "driver_path": "",
+  "user_agent": "ScrapImageBot/1.0",
 
   "scrap_lien_url": "",
   "scrap_lien_output": "products.txt",

--- a/settings_manager.py
+++ b/settings_manager.py
@@ -15,6 +15,7 @@ DEFAULT_SETTINGS = {
     "enable_update": True,
     "driver_path": "",
     "headless": True,
+    "user_agent": "ScrapImageBot/1.0",
 
     # Last used values for scrapers
     "scrap_lien_url": "",


### PR DESCRIPTION
## Summary
- add `user_agent` field in the default settings and example settings file
- expose a user‑agent editor in the Settings page
- support automatic user‑agent reading from `settings.json` when using `scraper_images.download_images`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e795bb4d8833086e488775ec814fc