### PR TITLE
Centralize default values in constants module

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -5,8 +5,10 @@ from .utils import (
     QtLogHandler,
     ToggleSwitch,
     CollapsibleSection,
-    ICONS_DIR,
     ICON_SIZE,
+)
+from interface_py.constants import (
+    ICONS_DIR,
     SIDEBAR_EXPANDED_WIDTH,
     SIDEBAR_COLLAPSED_WIDTH,
 )

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -43,12 +43,20 @@ from alpha_engine import AlphaEngine
 
 from .utils import (
     ICON_SIZE,
-    ICONS_DIR,
-    SIDEBAR_EXPANDED_WIDTH,
-    SIDEBAR_COLLAPSED_WIDTH,
     load_stylesheet,
     CollapsibleSection,
     ToggleSwitch,
+)
+from interface_py.constants import (
+    ICONS_DIR,
+    SIDEBAR_EXPANDED_WIDTH,
+    SIDEBAR_COLLAPSED_WIDTH,
+    COLLECTION_DEFAULT_SELECTOR as SLC_DEFAULT_SELECTOR,
+    DESCRIPTION_DEFAULT_SELECTOR as SDP_DEFAULT_SELECTOR,
+    PRICE_DEFAULT_SELECTOR as SPP_DEFAULT_SELECTOR,
+    VARIANT_DEFAULT_SELECTOR as MV_DEFAULT_SELECTOR,
+    IMAGES_DEFAULT_SELECTOR as DEFAULT_CSS_SELECTOR,
+    USER_AGENT,
 )
 from .workers import (
     ScrapLienWorker,
@@ -59,11 +67,6 @@ from .workers import (
     VariantFetchWorker,
 )
 
-from interface_py.scrap_collection import DEFAULT_SELECTOR as SLC_DEFAULT_SELECTOR
-from interface_py.scrap_description import DEFAULT_SELECTOR as SDP_DEFAULT_SELECTOR
-from interface_py.scrap_price import DEFAULT_SELECTOR as SPP_DEFAULT_SELECTOR
-from interface_py.moteur_variante import DEFAULT_SELECTOR as MV_DEFAULT_SELECTOR
-from interface_py.scraper_images import DEFAULT_CSS_SELECTOR, USER_AGENT
 
 class PageProfiles(QWidget):
     """Manage site profiles (selectors)."""

--- a/gui/utils.py
+++ b/gui/utils.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from interface_py.constants import (
+    ICONS_DIR,
+    SIDEBAR_EXPANDED_WIDTH,
+    SIDEBAR_COLLAPSED_WIDTH,
+)
 
 try:
     from PySide6.QtWidgets import (
@@ -46,12 +51,8 @@ except Exception:  # pragma: no cover - fallback for tests
             pass
 
 
-ICONS_DIR = Path(__file__).resolve().parents[1] / "icons"
-
 # Sidebar sizing constants
 ICON_SIZE = 24
-SIDEBAR_EXPANDED_WIDTH = 180
-SIDEBAR_COLLAPSED_WIDTH = ICON_SIZE + 16
 
 
 def load_stylesheet(path: str = "style.qss") -> None:

--- a/gui/workers.py
+++ b/gui/workers.py
@@ -10,10 +10,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from PySide6.QtCore import QThread, Signal
 
 from .utils import QtLogHandler
-from interface_py.scrap_collection import (
-    scrape_collection,
-    DEFAULT_NEXT_SELECTOR as SLC_DEFAULT_NEXT_SELECTOR,
-)
+from interface_py.scrap_collection import scrape_collection
+from interface_py.constants import DEFAULT_NEXT_SELECTOR as SLC_DEFAULT_NEXT_SELECTOR
 from interface_py import scraper_images
 from interface_py.scrap_description import scrape_description
 from interface_py.scrap_price import scrape_price

--- a/interface_py/constants.py
+++ b/interface_py/constants.py
@@ -1,0 +1,18 @@
+"""Common constants for the interface package."""
+from pathlib import Path
+
+# Default CSS selectors used across scrapers
+IMAGES_DEFAULT_SELECTOR = ".product-gallery__media-list img"
+COLLECTION_DEFAULT_SELECTOR = "div.product-card__info h3.product-card__title a"
+DEFAULT_NEXT_SELECTOR = "a[rel=\"next\"]"
+DESCRIPTION_DEFAULT_SELECTOR = ".rte"
+PRICE_DEFAULT_SELECTOR = ".price"
+VARIANT_DEFAULT_SELECTOR = ".variant-picker__option-values span.sr-only"
+
+# User agent string for HTTP requests
+USER_AGENT = "ScrapImageBot/1.0"
+
+# Sidebar layout constants
+ICONS_DIR = Path(__file__).resolve().parents[1] / "icons"
+SIDEBAR_EXPANDED_WIDTH = 180
+SIDEBAR_COLLAPSED_WIDTH = 40

--- a/interface_py/moteur_variante.py
+++ b/interface_py/moteur_variante.py
@@ -13,11 +13,10 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
 from interface_py.driver_utils import setup_driver
+from interface_py.constants import VARIANT_DEFAULT_SELECTOR
 
-DEFAULT_SELECTOR = ".variant-picker__option-values span.sr-only"
 
-
-def extract_variants(url: str, selector: str = DEFAULT_SELECTOR) -> tuple[str, list[str]]:
+def extract_variants(url: str, selector: str = VARIANT_DEFAULT_SELECTOR) -> tuple[str, list[str]]:
     """Return product title and list of variants found on *url*."""
     if not url.lower().startswith(("http://", "https://")):
         raise ValueError("URL must start with http:// or https://")
@@ -116,7 +115,10 @@ def main() -> None:
         "url", nargs="?", help="URL du produit (si absent, demande \u00e0 l'ex\u00e9cution)"
     )
     parser.add_argument(
-        "-s", "--selector", default=DEFAULT_SELECTOR, help="S\u00e9lecteur CSS des variantes"
+        "-s",
+        "--selector",
+        default=VARIANT_DEFAULT_SELECTOR,
+        help="S\u00e9lecteur CSS des variantes",
     )
     parser.add_argument(
         "-o", "--output", default="variants.txt", help="Fichier de sortie"

--- a/interface_py/scrap_collection.py
+++ b/interface_py/scrap_collection.py
@@ -23,11 +23,10 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 from interface_py.driver_utils import setup_driver
-
-# Default CSS selector used to locate product links in the collection page
-DEFAULT_SELECTOR = "div.product-card__info h3.product-card__title a"
-# Default CSS selector used to locate the "next page" button
-DEFAULT_NEXT_SELECTOR = "a[rel=\"next\"]"
+from interface_py.constants import (
+    COLLECTION_DEFAULT_SELECTOR,
+    DEFAULT_NEXT_SELECTOR,
+)
 
 
 
@@ -41,7 +40,7 @@ def _random_sleep(min_s: float = 1.0, max_s: float = 2.5) -> None:
 def scrape_collection(
     url: str,
     output_path: Path,
-    css_selector: str = DEFAULT_SELECTOR,
+    css_selector: str = COLLECTION_DEFAULT_SELECTOR,
     next_selector: str = DEFAULT_NEXT_SELECTOR,
     output_format: str = "txt",
 ) -> None:
@@ -145,7 +144,7 @@ def main() -> None:
     parser.add_argument(
         "-s",
         "--selector",
-        default=DEFAULT_SELECTOR,
+        default=COLLECTION_DEFAULT_SELECTOR,
         help="Selecteur CSS des liens produits (defaut: %(default)s)",
     )
     parser.add_argument(

--- a/interface_py/scrap_description.py
+++ b/interface_py/scrap_description.py
@@ -12,13 +12,12 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
 from interface_py.driver_utils import setup_driver
-
-DEFAULT_SELECTOR = ".rte"
-
+from interface_py.constants import DESCRIPTION_DEFAULT_SELECTOR
 
 
 
-def extract_html_description(url: str, css_selector: str = DEFAULT_SELECTOR) -> str:
+
+def extract_html_description(url: str, css_selector: str = DESCRIPTION_DEFAULT_SELECTOR) -> str:
     """Return the inner HTML of the first element matching *css_selector* on *url*."""
     if not url.lower().startswith(("http://", "https://")):
         raise ValueError("URL must start with http:// or https://")
@@ -62,7 +61,7 @@ def main() -> None:
     parser.add_argument(
         "-s",
         "--selector",
-        default=DEFAULT_SELECTOR,
+        default=DESCRIPTION_DEFAULT_SELECTOR,
         help="Sélecteur CSS de la description (defaut: %(default)s)",
     )
     parser.add_argument(

--- a/interface_py/scrap_price.py
+++ b/interface_py/scrap_price.py
@@ -12,11 +12,10 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
 from interface_py.driver_utils import setup_driver
+from interface_py.constants import PRICE_DEFAULT_SELECTOR
 
-DEFAULT_SELECTOR = ".price"
 
-
-def extract_price(url: str, css_selector: str = DEFAULT_SELECTOR) -> str:
+def extract_price(url: str, css_selector: str = PRICE_DEFAULT_SELECTOR) -> str:
     """Return the text content of the element matching *css_selector* on *url*."""
     if not url.lower().startswith(("http://", "https://")):
         raise ValueError("URL must start with http:// or https://")
@@ -60,7 +59,7 @@ def main() -> None:
     parser.add_argument(
         "-s",
         "--selector",
-        default=DEFAULT_SELECTOR,
+        default=PRICE_DEFAULT_SELECTOR,
         help="Sélecteur CSS du prix (defaut: %(default)s)",
     )
     parser.add_argument(

--- a/interface_py/scraper_images.py
+++ b/interface_py/scraper_images.py
@@ -33,8 +33,10 @@ from tqdm import tqdm
 
 from interface_py.driver_utils import setup_driver
 from settings_manager import SettingsManager, DEFAULT_SETTINGS
-
-DEFAULT_CSS_SELECTOR = ".product-gallery__media-list img"
+from interface_py.constants import (
+    IMAGES_DEFAULT_SELECTOR as DEFAULT_CSS_SELECTOR,
+    USER_AGENT,
+)
 
 # Path to the JSON file containing product names and ALT sentences
 ALT_JSON_PATH = Path(__file__).with_name("product_sentences.json")
@@ -65,9 +67,6 @@ def _open_folder(path: Path) -> None:
             subprocess.Popen(["xdg-open", path])
     except Exception as exc:
         logger.warning("Impossible d'ouvrir le dossier %s : %s", path, exc)
-
-
-USER_AGENT = "ScrapImageBot/1.0"
 
 
 def _download_binary(url: str, path: Path, user_agent: str = USER_AGENT) -> None:


### PR DESCRIPTION
## Summary
- add `interface_py/constants.py` with shared constants
- update scraper modules to use constants
- adjust GUI to reference new constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68776d2167c08330bc6f542fc06cc186