### PR TITLE
Refactor scraper_images into helper modules

### DIFF
--- a/interface_py/download_helpers.py
+++ b/interface_py/download_helpers.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import os
+import re
+from pathlib import Path
+
+import requests
+
+from interface_py.constants import USER_AGENT
+
+logger = logging.getLogger(__name__)
+
+
+def download_binary(url: str, path: Path, user_agent: str = USER_AGENT) -> None:
+    """Download binary content from *url* into *path* using *user_agent*."""
+    headers = {"User-Agent": user_agent}
+    try:
+        with requests.get(url, headers=headers, stream=True, timeout=10) as resp:
+            resp.raise_for_status()
+            with path.open("wb") as fh:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    if chunk:
+                        fh.write(chunk)
+    except requests.exceptions.RequestException as exc:  # pragma: no cover
+        raise RuntimeError(f"Failed to download {url}") from exc
+
+
+def save_base64(encoded: str, path: Path) -> None:
+    """Decode base64 *encoded* data and write it to *path*."""
+    try:
+        data = base64.b64decode(encoded)
+    except binascii.Error as exc:  # pragma: no cover - invalid data
+        raise RuntimeError("Invalid base64 image data") from exc
+    path.write_bytes(data)
+
+
+def unique_path(folder: Path, filename: str, reserved: set[Path]) -> Path:
+    """Return a unique ``Path`` in *folder* for *filename*."""
+    base, ext = os.path.splitext(filename)
+    candidate = folder / filename
+    counter = 1
+    while candidate.exists() or candidate in reserved:
+        candidate = folder / f"{base}_{counter}{ext}"
+        counter += 1
+    reserved.add(candidate)
+    return candidate
+
+
+def handle_image(
+    element, folder: Path, index: int, user_agent: str, reserved: set[Path]
+) -> tuple[Path, str | None]:
+    """Return target path and optional URL for *element* image."""
+    src = (
+        element.get_attribute("src")
+        or element.get_attribute("data-src")
+        or element.get_attribute("data-srcset")
+    )
+    if not src:
+        raise RuntimeError("Aucun attribut src / data-src trouvé pour l'image")
+
+    if " " in src and "," in src:
+        candidates = [s.strip().split(" ")[0] for s in src.split(",")]
+        src = candidates[-1]
+
+    logger.debug("Téléchargement de l'image : %s", src)
+
+    if src.startswith("data:image"):
+        header, encoded = src.split(",", 1)
+        ext = header.split("/")[1].split(";")[0]
+        filename = f"image_base64_{index}.{ext}"
+        target = unique_path(folder, filename, reserved)
+        save_base64(encoded, target)
+        return target, None
+
+    if src.startswith("//"):
+        src = "https:" + src
+
+    raw_filename = os.path.basename(src.split("?")[0])
+    filename = re.sub(r"-\d+(?=\.\w+$)", "", raw_filename)
+    target = unique_path(folder, filename, reserved)
+    return target, src

--- a/interface_py/rename_helpers.py
+++ b/interface_py/rename_helpers.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import logging
+import random
+import re
+import unicodedata
+from pathlib import Path
+
+from .download_helpers import unique_path
+
+# Path to the JSON file containing product names and ALT sentences
+ALT_JSON_PATH = Path(__file__).with_name("product_sentences.json")
+
+# Enable use of ALT sentences for renaming images by default
+USE_ALT_JSON = True
+
+logger = logging.getLogger(__name__)
+
+# Cache for the ALT sentences loaded from JSON
+_ALT_SENTENCES_CACHE: dict[Path, dict] = {}
+
+
+def load_alt_sentences(path: Path = ALT_JSON_PATH) -> dict:
+    """Load and cache ALT sentences from *path*."""
+    path = Path(path)
+    cached = _ALT_SENTENCES_CACHE.get(path)
+    if cached is not None:
+        return cached
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception as exc:  # pragma: no cover - file missing or invalid
+        logger.warning("Impossible de charger %s : %s", path, exc)
+        data = {}
+    _ALT_SENTENCES_CACHE[path] = data
+    return data
+
+
+def clean_filename(text: str) -> str:
+    """Return *text* transformed into a safe file name."""
+    normalized = unicodedata.normalize("NFD", text)
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    ascii_text = ascii_text.lower()
+    ascii_text = re.sub(r"\s+", "_", ascii_text)
+    ascii_text = re.sub(r"[^a-z0-9_-]", "", ascii_text)
+    return ascii_text
+
+
+def rename_with_alt(path: Path, sentences: dict, warned: set[str], reserved: set[Path]) -> Path:
+    """Rename *path* using ALT sentences if available."""
+    product_key = path.parent.name.replace("_", " ")
+    phrase_list = sentences.get(product_key)
+    if not phrase_list:
+        if product_key not in warned:
+            logger.warning(
+                "Cle '%s' absente de product_sentences.json, pas de renommage",
+                product_key,
+            )
+            warned.add(product_key)
+        return path
+
+    alt_phrase = random.choice(phrase_list)
+    filename = clean_filename(alt_phrase) + path.suffix
+    target = path.parent / filename
+    if target != path and target.exists():
+        target = unique_path(path.parent, filename, reserved)
+    try:
+        path.rename(target)
+    except OSError as exc:  # pragma: no cover - rename failure
+        logger.warning("Echec du renommage %s -> %s : %s", path, target, exc)
+        return path
+    return target


### PR DESCRIPTION
## Summary
- break up `scraper_images` into helper modules
- adjust tests for new import paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68777cc7d6dc8330bed0bdd3f048bc7a